### PR TITLE
Bump component-cookie to 1.1.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@segment/clear-cookies",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Clear document cookies",
   "keywords": [
     "cookie",
@@ -21,7 +21,7 @@
   },
   "homepage": "https://github.com/segmentio/clear-cookies#readme",
   "dependencies": {
-    "component-cookie": "^1.1.2"
+    "component-cookie": "^1.1.4"
   },
   "devDependencies": {
     "@segment/eslint-config": "^3.1.1",


### PR DESCRIPTION
`component-cookie` used to depend on `debug: *`, which has caused problems for upstream dependents on this package. The newest version of `component-cookie`, `1.1.4`, fixes this issue.

See: https://github.com/component/cookie/pull/15